### PR TITLE
Update guzzlehttp/guzzle dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
   ],
   "require": {
     "php": ">=5.5.0",
-    "guzzlehttp/guzzle": "^6.2"
+    "guzzlehttp/guzzle": "^6.2|^7.0"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
I've noticed that there are not much difference between ^6.2 and ^7.0 guzzlehttp/guzzle. So I had the courage to update the dependency
